### PR TITLE
Add handlers for the oauth redirect back to the app.

### DIFF
--- a/ConnectDemo/ConnectController.swift
+++ b/ConnectDemo/ConnectController.swift
@@ -8,8 +8,8 @@ import UIKit
 
 
 
-class ConnectController: UIViewController, WKNavigationDelegate {
-    var webView: WKWebView!
+class ConnectController: UIViewController, WKNavigationDelegate, WKUIDelegate {
+    var widgetWebView: WKWebView!
     /**
      `appScheme` needs to match the `ui_message_webview_url_scheme` configuration value, if set.
      Most navigation events will use that scheme instead of `atrium://`. It is also used to redirect
@@ -17,24 +17,57 @@ class ConnectController: UIViewController, WKNavigationDelegate {
 
      See the documentation for more details
      https://atrium.mx.com/docs#embedding-in-webviews
+     https://docs.mx.com/api#connect_postmessage_events
      */
-    let appScheme = "appscheme://"
-    let atriumScheme = "atrium://"
+    let appScheme = "appscheme://" // Your apps custom scheme
+    let atriumScheme = "atrium://" // MX atrium's default scheme (deprecated)
+    let mxScheme = "mx://" // MX default scheme
 
     /**
-     Handle all navigation events from the webview. Cancel all navigation events that start with your `appScheme`,
-     or `atriumScheme`. Instead of post messages, we send that data via navigation events since webviews
-     don't have a reliable postMessage API.
+     In a 'real' app, you would want to get this one time use URL from MX.
+
+     See the documentation for more details:
+     https://atrium.mx.com/docs#get-a-url
+     https://docs.mx.com/api#connect_request_a_url
+     */
+    let widgetURL = "WIDGET URL HERE"
+
+
+    override func loadView() {
+        let webPreferences = WKPreferences()
+        webPreferences.javaScriptCanOpenWindowsAutomatically = true
+
+        let webConfiguration = WKWebViewConfiguration()
+        webConfiguration.preferences = webPreferences
+
+        widgetWebView = WKWebView(frame: .zero, configuration: webConfiguration)
+        widgetWebView.navigationDelegate = self
+        widgetWebView.uiDelegate = self
+        view = widgetWebView
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        widgetWebView.load(URLRequest(url: URL(string:widgetURL)!))
+    }
+
+
+    /**
+     Handle all navigation events from the webview. Cancel all postmessages from
+     MX as they are not valid urls.
 
      See the post message documentation for more details:
      https://atrium.mx.com/docs#postmessage-events
+     https://docs.mx.com/api#connect_postmessage_events
      */
     func webView(_ webView: WKWebView,
                  decidePolicyFor navigationAction: WKNavigationAction,
                  decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
         let url = navigationAction.request.url?.absoluteString
-        print("************************************", url)
-        let isPostMessageFromMX = url?.hasPrefix(appScheme) == true || url?.hasPrefix(atriumScheme) == true
+        let isPostMessageFromMX = url?.hasPrefix(appScheme) == true
+                                  || url?.hasPrefix(atriumScheme) == true
+                                  || url?.hasPrefix(mxScheme) == true
 
         if (isPostMessageFromMX) {
             let urlc = URLComponents(string: url ?? "")
@@ -50,12 +83,43 @@ class ConnectController: UIViewController, WKNavigationDelegate {
             return
         }
 
-        // Only allow requests with great caution. Allowing a navigation action
-        // could navigate the user away from connect and lose their session.
+        // Make sure to open links in the user agent, not the webview.
+        // Allowing a navigation action could navigate the user away from
+        // connect and lose their session.
+        if let urlToOpen = url {
+            // Don't open the url, if it is the widget url itself on the first load
+            if (urlToOpen != widgetURL) {
+                UIApplication.shared.open(URL(string: urlToOpen)!)
+            }
+        }
+
         decisionHandler(.allow)
     }
 
-    // Helpful methods for debugging errors
+    /**
+     Sometimes the widget will make calls to `window.open` these calls will end up here if
+     `javaScriptCanOpenWindowsAutomatically` is set to `true`. When doing this, make sure
+     to return `nil` here so you don't end up overwriting the widget webview instance. Generally speaking
+     it is best to open the url in a new browser session.
+     */
+    func webView(_ webView: WKWebView, createWebViewWith configuration: WKWebViewConfiguration, for navigationAction: WKNavigationAction, windowFeatures: WKWindowFeatures) -> WKWebView? {
+        let url = navigationAction.request.url?.absoluteString
+
+        print("************************************", url ?? "")
+
+        if let urlToOpen = url {
+            // Don't open the url, if it is the widget url itself on the first load
+            if (urlToOpen != widgetURL) {
+                UIApplication.shared.open(URL(string: urlToOpen)!)
+            }
+        }
+
+        return nil
+    }
+
+    /**
+     Helpful methods for debugging webview failures.
+     */
     func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
         print("Failed during navigation!", error)
     }
@@ -75,36 +139,12 @@ class ConnectController: UIViewController, WKNavigationDelegate {
             if let json = try JSONSerialization.jsonObject(with: Data(metadataString.utf8), options: []) as? [String: Any] {
                 if let url = json["url"] as? String {
                     // open safari with the url from the json payload
-                    print(url)
                     UIApplication.shared.open(URL(string: url)!)
                 }
             }
         } catch let error as NSError {
             print("Failed to parse payload: \(error.localizedDescription)")
         }
-    }
-
-    override func loadView() {
-        let webConfiguration = WKWebViewConfiguration()
-        webView = WKWebView(frame: .zero, configuration: webConfiguration)
-        webView.navigationDelegate = self
-        view = webView
-    }
-
-    override func viewDidLoad() {
-        super.viewDidLoad()
-
-        /**
-         In a 'real' app, you would want to get this one time use URL from MX. For demo purposes, it is
-         simply hardcoded here.
-
-         See the documentation for more details:
-         https://atrium.mx.com/docs#get-a-url
-         */
-        let mxConnectURL = URL(string:"Connect widget url here")
-
-        let myRequest = URLRequest(url: mxConnectURL!)
-        webView.load(myRequest)
     }
 
     /**
@@ -117,3 +157,4 @@ class ConnectController: UIViewController, WKNavigationDelegate {
         completionHandler(.useCredential, URLCredential(trust: serverTrust))
     }
 }
+

--- a/ConnectDemo/ConnectController.swift
+++ b/ConnectDemo/ConnectController.swift
@@ -33,6 +33,7 @@ class ConnectController: UIViewController, WKNavigationDelegate {
                  decidePolicyFor navigationAction: WKNavigationAction,
                  decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
         let url = navigationAction.request.url?.absoluteString
+        print("************************************", url)
         let isPostMessageFromMX = url?.hasPrefix(appScheme) == true || url?.hasPrefix(atriumScheme) == true
 
         if (isPostMessageFromMX) {

--- a/ConnectDemo/SceneDelegate.swift
+++ b/ConnectDemo/SceneDelegate.swift
@@ -47,6 +47,32 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // to restore the scene back to its current state.
     }
 
+    func scene(_ scene: UIScene,
+                        openURLContexts URLContexts: Set<UIOpenURLContext>) {
+        let incomingURL = URLContexts.first?.url
 
+        // appscheme://oauth_complete?status=success&member_guid=MBR-1
+        // appscheme://oauth_complete?status=error&member_guid=MBR-1
+        if (incomingURL?.scheme == "appscheme" && incomingURL?.host == "oauth_complete") {
+            // This is an OAuth redirect back to the app from MX
+            var status = "",
+                memberGuid = ""
+
+            let urlc = URLComponents(string: incomingURL?.absoluteString ?? "")
+
+            for item in urlc?.queryItems ?? [] {
+                switch item.name {
+                case "status":
+                    status = item.value!
+                case "member_guid":
+                    memberGuid = item.value!
+                default:
+                    print("ERROR: Unexpected item in oauth query string", item.name)
+                }
+            }
+
+            print("Recived a status of: \(status) and member of \(memberGuid)")
+        }
+    }
 }
 


### PR DESCRIPTION
This adds handles and some logging around the oauth urls back to the app and serves as an example of how one might handle the redirect back to their own app.

This simply logs out if it was success or error and what the member guid was.